### PR TITLE
Update me2beats_Toggle open items inline editors (+ zoom).lua

### DIFF
--- a/Items/me2beats_Toggle open items inline editors (+ zoom).lua
+++ b/Items/me2beats_Toggle open items inline editors (+ zoom).lua
@@ -6,7 +6,9 @@
 
 local r = reaper
 
-local action = r.NamedCommandLookup'_SWS_TOGZOOMIONLY'
+-- https://forum.cockos.com/showthread.php?t=279526#23
+local version = tonumber(r.GetAppVersion():match('[%d%.]+')) -- mod
+local action = version <= 6.75 and r.NamedCommandLookup'_SWS_TOGZOOMIONLY' or r.NamedCommandLookup'_SWS_TOGZOOMIONLY_NO_ENV' -- mod
 
 local state = r.GetToggleCommandState(action)
 


### PR DESCRIPTION
The script stopped working in 6.76 and later builds due to overhaul of the track zoom function which had become incompatible with the originally used SWS action.

So made the action conditional on the REAPER build.